### PR TITLE
Add feature tests for project API endpoints

### DIFF
--- a/backend/app/Models/Project.php
+++ b/backend/app/Models/Project.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model
 {
+    use HasFactory;
     //
 }

--- a/backend/database/factories/ProjectFactory.php
+++ b/backend/database/factories/ProjectFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class ProjectFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Project::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $title = $this->faker->sentence;
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title),
+            'thumbnail_url' => $this->faker->imageUrl(),
+            'short_description' => $this->faker->paragraph,
+            'long_description_markdown' => $this->faker->paragraphs(3, true), // Corrected column name
+            'hero_image_url' => $this->faker->imageUrl(), // Added hero_image_url
+            'project_url' => $this->faker->url(), // Added project_url
+            'status' => $this->faker->randomElement(['draft', 'published']),
+            // Removed image_gallery, files, meta_title, meta_description, meta_keywords
+        ];
+    }
+
+    /**
+     * Indicate that the project is published.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function published()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => 'published',
+            ];
+        });
+    }
+
+    /**
+     * Indicate that the project is a draft.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function draft()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => 'draft',
+            ];
+        });
+    }
+}

--- a/backend/tests/Feature/ProjectApiTest.php
+++ b/backend/tests/Feature/ProjectApiTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\Project;
+
+class ProjectApiTest extends TestCase
+{
+    use RefreshDatabase; // Resets the database for each test
+
+    /**
+     * Test the /api/projects endpoint.
+     *
+     * @return void
+     */
+    public function test_get_projects_endpoint(): void
+    {
+        // Create some projects (published and unpublished)
+        Project::factory()->create(['status' => 'published', 'title' => 'Published Project 1']);
+        Project::factory()->create(['status' => 'published', 'title' => 'Published Project 2']);
+        Project::factory()->create(['status' => 'draft', 'title' => 'Draft Project']);
+
+        $response = $this->getJson('/api/projects');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2) // Expecting only 2 published projects
+            ->assertJsonStructure([
+                '*' => [ // '*' means each item in the array
+                    'id',
+                    'title',
+                    'slug',
+                    'thumbnail_url',
+                    'short_description',
+                ]
+            ]);
+
+        // Optionally, assert that specific data is NOT present if needed,
+        // e.g., ensure the draft project is not returned.
+        $response->assertJsonMissing(['title' => 'Draft Project']);
+    }
+
+    /**
+     * Test the /api/projects/{slug} endpoint.
+     *
+     * @return void
+     */
+    public function test_get_single_project_endpoint(): void
+    {
+        // Create a published project
+        $publishedProject = Project::factory()->published()->create(['title' => 'My Awesome Project']);
+
+        // Create a draft project
+        $draftProject = Project::factory()->draft()->create(['title' => 'My Secret Project']);
+
+        // Test fetching the published project
+        $responsePublished = $this->getJson('/api/projects/' . $publishedProject->slug);
+        $responsePublished->assertStatus(200)
+            ->assertJson([ // Check for specific fields including the corrected one
+                'id' => $publishedProject->id,
+                'title' => $publishedProject->title,
+                'slug' => $publishedProject->slug,
+                'thumbnail_url' => $publishedProject->thumbnail_url,
+                'hero_image_url' => $publishedProject->hero_image_url, // Assert this
+                'short_description' => $publishedProject->short_description,
+                'long_description_markdown' => $publishedProject->long_description_markdown,
+                'project_url' => $publishedProject->project_url, // Assert this
+                'status' => 'published',
+            ])
+            ->assertJsonStructure([ // Verify the overall structure for a single project based on migration
+                'id',
+                'title',
+                'slug',
+                'thumbnail_url',
+                'hero_image_url',
+                'short_description',
+                'long_description_markdown',
+                'project_url',
+                'status',
+                'created_at',
+                'updated_at',
+                // Removed image_gallery, files, and meta fields as they are not in the migration
+            ]);
+
+        // Test fetching the draft project (should return 404)
+        $responseDraft = $this->getJson('/api/projects/' . $draftProject->slug);
+        $responseDraft->assertStatus(404);
+
+        // Test fetching a non-existent project (should return 404)
+        $responseNotFound = $this->getJson('/api/projects/non-existent-slug');
+        $responseNotFound->assertStatus(404);
+    }
+}


### PR DESCRIPTION
- Create ProjectApiTest.php with tests for /api/projects and /api/projects/{slug}.
- Add ProjectFactory to generate test data.
- Update Project model to use HasFactory trait.
- Ensure tests align with the existing database migration for the projects table, including corrections for long_description_markdown, hero_image_url, and project_url, and removal of fields not in migration (image_gallery, files, meta fields).
- Resolve SQLite driver issues in the testing environment.